### PR TITLE
fix: ignore k8s service annotations

### DIFF
--- a/terraform/deployment/provider.tf
+++ b/terraform/deployment/provider.tf
@@ -25,4 +25,7 @@ provider "kubernetes" {
   client_key             = data.upcloud_kubernetes_cluster.example.client_key
   cluster_ca_certificate = data.upcloud_kubernetes_cluster.example.cluster_ca_certificate
   host                   = data.upcloud_kubernetes_cluster.example.host
+  ignore_annotations = [
+    "^service\\.beta\\.kubernetes\\.io\\/upcloud-load-balancer.*"
+  ]
 }


### PR DESCRIPTION
With the current implementation subsequent apply operations cause the following issue:

```
  # module.deployment.kubernetes_service.this will be updated in-place
  ~ resource "kubernetes_service" "this" {
        id                     = "default/hello-uks2"
        # (2 unchanged attributes hidden)

      ~ metadata {
          ~ annotations      = {
              - "service.beta.kubernetes.io/upcloud-load-balancer-id"   = "0ad0b534-8db0-4c90-83f8-dd266b0c2fa3" -> null
              - "service.beta.kubernetes.io/upcloud-load-balancer-name" = "0d93a761-595a-4a1c-b094-b342f9ab57ea-default-hello-uks2" -> null
            }
 ...
```

This PR changes the k8s TF provider to ignore annotations set by CCM upon LB creation. Having it on the provider level means new services can be added without adding `ignore_changes` to each individual service resource.

Related TF docs: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#ignore-kubernetes-annotations-and-labels